### PR TITLE
Fix non-interactive interface choosing

### DIFF
--- a/sbin/netcardconfig
+++ b/sbin/netcardconfig
@@ -683,7 +683,20 @@ while (true); do
       $DIALOG --menu "$MESSAGE1" 18 60 12 "${DEVICELIST[@]}" "${EXITMENU[@]}" 2>"$TMP" || bailout
       read -r DV <"$TMP" ; rm -f "$TMP"
     else
-      DV="${NET_DEV}"
+      # we have interface name so we need to find its number in NETDEVICES
+      DV=0
+      found=false
+      for DV in "${!NETDEVICES[@]}"; do
+        if [[ "${NETDEVICES[$DV]}" =~ ^"${NET_DEV} " ]]; then
+          found=true
+          break
+        fi
+      done
+      if ! "${found}"; then
+        echo "There is no interface ${NET_DEV} in the system" >&2
+        bailout 1
+      fi
+
       [[ -z "${IFACEDONE}" ]] || bailout
     fi
     [ "$DV" = "$EXITKEY" ] && bailout


### PR DESCRIPTION
In interactive mode user choose an interface and its number is used
in the code. In function 'configiface' the actual interface is taken
from NETDEVICES by this number.

In non-interactive mode we have an interface name and it was used as
index in NETDEVICES which failed and the 1st interface was always taken.
It does not matter what interface was passed in NET_DEV variable script
tried to configure eth0.

Fix it with getting interface number by its name.