### PR TITLE
grml-network: Fix obsolete nmap command line options

### DIFF
--- a/sbin/grml-network
+++ b/sbin/grml-network
@@ -55,7 +55,7 @@ main(){
     STATUS=""
     GW="$(echo $(route -n | awk '/^0\.0\.0\.0/{print $2}'))"
     GWDEV="$(echo $(route -n | awk '/^0\.0\.0\.0/{print $NF}'))"
-    NMAP="$(nmap -sP --host_timeout 4000 --max_rtt_timeout 4000ms $GW 2>/dev/null)"
+    NMAP="$(nmap -sP --host-timeout 4 --max-rtt-timeout 4 $GW 2>/dev/null)"
 
     if [ $? -eq 0 ]; then
       if ! echo "$NMAP" | grep -q '0 hosts up' ; then


### PR DESCRIPTION
host_timeout and max_rtt_timeout have been deprecated and undocumented
aliases for host-timeout and max-rtt-timeout.

The options have been removed from nmap in v7.70.
See: https://github.com/nmap/nmap/commit/23d95f5

While at it also use seconds instead of 'ms'. Quoting nmap(1):

  TIMING AND PERFORMANCE:
    Options which take <time> are in seconds, or append 'ms' (milliseconds),
    's' (seconds), 'm' (minutes), or 'h' (hours) to the value (e.g. 30m).

Closes: grml/grml-network#6