### PR TITLE
netcardconfig: Run ifdown immediately before configuring the network …

### DIFF
--- a/sbin/netcardconfig
+++ b/sbin/netcardconfig
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Filename:      grml-network
+# Filename:      netcardconfig
 # Purpose:       configuration script for network
 # Authors:       Michael Prokop <mika@grml.org>, Marcel Wichern 2006, Klaus Knopper 2002, Niall Walsh + Stefan Lippers-Hollmann 2004-2007
 # Bug-Reports:   see http://grml.org/bugs/
@@ -188,8 +188,7 @@ configiface() {
   DEVICE=${NETDEVICES[$DV]}
   device2props
   DV=$DEVICENAME
-  ifdown "${DV}" --force
-  sleep 3
+
   # INTERACTIVE=true
   if "${INTERACTIVE}" ; then
     # Setup wireless options?
@@ -712,6 +711,7 @@ while (true); do
   IFACEDONE=""
   while [ -n "$DV" ] && [ -z "$IFACEDONE" ]; do
     configiface "${METHOD}" "${IPADDR}" "${NETMASK}" "${GATEWAY}" "${DNS}"
+    ifdown "${DV}" --force
     if ! ifup $DV; then
       if "${INTERACTIVE}" ; then
         $DIALOG --yesno "$MESSAGE14" 15 50 || IFACEDONE="DONE"


### PR DESCRIPTION
…device

When running netcardconfig the network device is set offline before the
configuration is completed. The network configuration should only be
touched after everything is set.

While at it also removed the sleep phase. The network interface should
be released and down fine after ifdown is completed.

Closes: grml/grml-network#8