### PR TITLE
d/control: set Rules-Requires-Root: no

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -13,6 +13,7 @@ Vcs-git: https://github.com/grml/grml-network/
 Vcs-Browser: https://github.com/grml/grml-network/
 Origin: Grml
 Bugs: mailto:bugs@grml.org
+Rules-Requires-Root: no
 
 Package: grml-network
 Architecture: all


### PR DESCRIPTION
No need for fakeroot at build time.