### PR TITLE
netcardconfig: Avoid full path usage for invocation of ip(8)

### DIFF
--- a/sbin/netcardconfig
+++ b/sbin/netcardconfig
@@ -55,7 +55,7 @@ writeiwline() {
 
   for mod in /sys/module/rt2??0/ ; do
     if [ -d "$mod" ]; then
-      IWPREUPLINE="$IWPREUPLINE\tpre-up /sbin/ip link set $DV up\n"
+      IWPREUPLINE="$IWPREUPLINE\tpre-up ip link set $DV up\n"
       break
     fi
   done


### PR DESCRIPTION
iproute2 used to ship a symlink from /sbin/ip to /bin/ip for backwards compatibility, though this got recently dropped (see https://lists.debian.org/debian-devel/2024/08/msg00208.html).

While this got restored again afterwards, let's be prepared!